### PR TITLE
Make Usage Object Nullable for Streaming

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1486,9 +1486,13 @@
                                 "description": "A list of chat completion choices."
                             },
                             "usage": {
-                                "$ref": "#/components/schemas/Usage",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Usage"
+                                    }
+                                ],
                                 "nullable": true,
-                                "description": "Usage statistics for the completion request. Only present in the final chunk when stream_options.include_usage is set."
+                                "description": "Usage statistics for the completion request. When stream_options.include_usage is set, the final chunk before [DONE] will contain the full usage statistics, and all other chunks will include usage with a null value."
                             }
                         }
                     }

--- a/src/sudo/models/chatcompletionchunk.py
+++ b/src/sudo/models/chatcompletionchunk.py
@@ -32,7 +32,7 @@ class DataTypedDict(TypedDict):
     r"""A list of chat completion choices."""
     system_fingerprint: NotRequired[Nullable[str]]
     r"""This fingerprint represents the backend configuration that the model runs with."""
-    usage: NotRequired[UsageTypedDict]
+    usage: NotRequired[Nullable[UsageTypedDict]]
 
 
 class Data(BaseModel):
@@ -54,12 +54,12 @@ class Data(BaseModel):
     system_fingerprint: OptionalNullable[str] = UNSET
     r"""This fingerprint represents the backend configuration that the model runs with."""
 
-    usage: Optional[Usage] = None
+    usage: OptionalNullable[Usage] = UNSET
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = ["system_fingerprint", "usage"]
-        nullable_fields = ["system_fingerprint"]
+        nullable_fields = ["system_fingerprint", "usage"]
         null_default_fields = []
 
         serialized = handler(self)


### PR DESCRIPTION
make usage object nullable so typecheck doesn't fail on chunks without it

- **feat: regenerate speakeasy with images gen**
- **fix: bring back readme fixes**
- **test: image gen**
- **feat: tests fix**
- **fix: handling for errors**
- **feat: make usage object nullable so typecheck doesn't fail on chunks without it**
